### PR TITLE
Implementation of Department-Specific Data Retrieval Endpoints

### DIFF
--- a/SalesWebMVc/Controllers/DepartmentsController.cs
+++ b/SalesWebMVc/Controllers/DepartmentsController.cs
@@ -49,6 +49,61 @@ namespace SalesWebMVc.Controllers
 
 			return response;
 		}
+		
+		[HttpGet("{id}/sellers")]
+		[SwaggerOperation(
+			Summary = "Obter todos os vendedores de um departamento",
+			Description = "Retorna todos os vendedores do departemento pelo id"
+		)]
+		[SwaggerResponse(200, "Vendedores encontrados", typeof(IEnumerable<Seller>))]
+		[SwaggerResponse(404, "Nenhum vendedor encontrado")]
+		public async Task<ActionResult<IEnumerable<Seller>>> GetSellers(int id)
+		{
+			var response = await _departmentService.FindSellersAsync(id);
+
+			return response;
+		}
+
+		[HttpGet("{id}/sales")]
+		[SwaggerOperation(
+			Summary = "Obter todas as vendas de um departamento",
+			Description = "Retorna todas as vendas do departamento pelo id"
+		)]
+		[SwaggerResponse(200, "Vendas encontradas", typeof(IEnumerable<SalesRecord>))]
+		[SwaggerResponse(404, "Nenhuma venda encontrada")]
+		public async Task<ActionResult<IEnumerable<SalesRecord>>> GetSales(int id)
+		{
+			var response = await _departmentService.FindSalesAsync(id);
+
+			return response;
+		}
+
+		[HttpGet("{id}/total-sales")]
+		[SwaggerOperation(
+			Summary = "Obter o total vendido pelo departamento",
+			Description = "Retorna o total em reais de vendas do departamento pelo id"
+		)]
+		[SwaggerResponse(200, "Total de vendas encontrado", typeof(string))]
+		[SwaggerResponse(404, "Nenhuma venda encontrada")]
+		public async Task<ActionResult<string>> GetTotalSales(int id)
+		{
+			var response = await _departmentService.TotalSalesAsync(id);
+
+			return response;
+		}
+		[HttpGet("{id}/cost")]
+		[SwaggerOperation(
+			Summary = "Obter o custo total do departamento",
+			Description = "Retorna o custo total em reais do departamento pelo id"
+		)]
+		[SwaggerResponse(200, "Custo total encontrado", typeof(string))]
+		[SwaggerResponse(404, "Nenhum custo encontrado")]
+		public async Task<ActionResult<string>> GetCost(int id)
+		{
+			var response = await _departmentService.CostAsync(id);
+
+			return response;
+		}
 
 		[HttpPost]
 		[SwaggerOperation(


### PR DESCRIPTION
### This Pull Request introduces three new GET endpoints to the API, enabling the retrieval of department-specific data related to sellers, sales, and total sales amounts:

- **GET** /api/Departments/{id}/sellers: Retrieves a list of all sellers associated with a given department, identified by its id.

- **GET** /api/Departments/{id}/sales: Retrieves all sales records belonging to a specific department, identified by its id.

- **GET** /api/Departments/{id}/total-sales: Calculates and returns the total sales value for a particular department, identified by its id.

All endpoints return data in JSON format except for total-sales.

### Motivation:

These endpoints were added to provide a more granular and efficient way to access department-level data, supporting functionalities such as departmental performance analysis and reporting.

### Notes:

- The total sales value is returned as a formatted string representing Brazilian currency (e.g., "R$ 1.234,56") rather than a raw integer or double value.

### Checklist:

- [x]  Implementation of endpoints
- [x] Unit and integration tests
- [ ] Update API documentation